### PR TITLE
Upgrade to Rustler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - 2021-06-12
+## [0.2.0] - 2021-06-12
 ### Changed
 - Migrate from erlang_nif-sys to Rustler
 - Return map objects instead of property lists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - 2021-06-12
+### Changed
+- Migrate from erlang_nif-sys to Rustler
+- Return map objects instead of property lists
+
 ## [0.1.9] - 2017-07-03
 ### Changed
 - Upgrade erlang_nif-sys to support Erlang/OTP 20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Migrate from erlang_nif-sys to Rustler
 - Return map objects instead of property lists
+- Accept and return binary strings instead of char lists
 
 ## [0.1.9] - 2017-07-03
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,7 @@ license = "Apache-2.0"
 name = "epwd_rs"
 crate-type = ["cdylib"]
 
-[dependencies.users]
-git = "https://github.com/ogham/rust-users.git"
-tag = "v0.5.1"
-
 [dependencies]
 libc = ">=0.2"
 erlang_nif-sys = "0.6.2"
+users = "^0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 libc = ">=0.2"
-erlang_nif-sys = "0.6.2"
-users = "^0.5.1"
+rustler = "0.22.0-rc.1"
+users = "^0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epwd-rs"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Nathan Fiedler <nathanfiedler@fastmail.fm>"]
 description = "Erlang interface to POSIX user database via Rust."
 homepage = "https://github.com/nlfiedler/epwd.rs"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Include as a dependency in your release, using rebar3...
 
 ```
 {deps, [
-    {epwd_rs, {git, "https://github.com/nlfiedler/epwd_rs", {tag, "0.1.9"}}}
+    {epwd_rs, {git, "https://github.com/nlfiedler/epwd_rs", {tag, "0.2.0"}}}
 ]}.
 ```
 
@@ -37,7 +37,7 @@ Be sure to include `epwd_rs` in the `included_applications` list of your Erlang 
 ```
 defp deps do
   [
-    {:epwd_rs, github: "nlfiedler/epwd.rs", tag: "0.1.9", runtime: false}
+    {:epwd_rs, github: "nlfiedler/epwd.rs", tag: "0.2.0", runtime: false}
   ]
 end
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,119 +14,58 @@
  * limitations under the License.
  */
 
-#[macro_use]
-extern crate erlang_nif_sys;
+extern crate rustler;
 extern crate users;
 extern crate libc;
 
-use erlang_nif_sys::*;
-use std::ffi::CString;
-use std::mem::uninitialized;
-use libc::uid_t;
+use rustler::NifMap;
 use users::os::unix::UserExt;
+use libc::{uid_t, gid_t};
 
-/// Create NIF module data and init function.
-nif_init!(b"epwd_rs\0", None, None, None, None,
-     nif!(b"getpwnam\0", 1, getpwnam),
-     nif!(b"getpwuid\0", 1, getpwuid)
-    );
+// Create NIF module data and init function.
+rustler::init!("epwd_rs", [getpwnam, getpwuid]);
 
 /// Retrieve the details for the named user as a property list.
-extern "C" fn getpwnam(env: *mut ErlNifEnv,
-                       argc: c_int,
-                       args: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
-    if argc == 1 {
-        // need to allocate the space for the incoming string
-        // (256 should be enough for anybody)
-        let mut name:Vec<c_uchar> = Vec::with_capacity(256);
-        let name_len = unsafe { enif_get_string(env, *args.offset(0), name.as_mut_ptr(), 256,
-            ErlNifCharEncoding::ERL_NIF_LATIN1) };
-        if name_len == 0 {
-            return make_err_result(env, "invalid name argument");
-        }
-        unsafe { name.set_len((name_len - 1) as usize) };
-        let rname = std::str::from_utf8(&name);
-        if rname.is_err() {
-            return make_err_result(env, "invalid name");
-        }
-        match users::get_user_by_name(rname.unwrap()) {
-            Some(user) => {
-                let result = make_user_proplist(env, user);
-                make_ok_result(env, &result)
-            },
-            None => make_err_result(env, "no such user")
-        }
-    } else {
-        unsafe { enif_make_badarg(env) }
+#[rustler::nif]
+fn getpwnam(name: Vec<u8>) -> Result<User, Vec<u8>> {
+   let rname = std::str::from_utf8(&name);
+   if rname.is_err() {
+       return Err("invalid name".as_bytes().to_vec());
+   }
+
+    match users::get_user_by_name(&rname.unwrap()) {
+        Some(user) => Ok(User::from(user)),
+        None => Err("no such user".as_bytes().to_vec())
     }
 }
 
-/// Retrieve the details for the identified user as a property list.
-extern "C" fn getpwuid(env: *mut ErlNifEnv,
-                       argc: c_int,
-                       args: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
-    let mut uid:c_int = unsafe { uninitialized() };
-    if argc == 1 &&
-       0 != unsafe { enif_get_int(env, *args.offset(0), &mut uid) } {
-        match users::get_user_by_uid(uid as uid_t) {
-            Some(user) => {
-                let result = make_user_proplist(env, user);
-                make_ok_result(env, &result)
-            },
-            None => make_err_result(env, "no such user")
-        }
-    } else {
-        unsafe { enif_make_badarg(env) }
+#[rustler::nif]
+fn getpwuid(uid: u32) -> Result<User, Vec<u8>> {
+    match users::get_user_by_uid(uid as libc::uid_t) {
+        Some(user) => Ok(User::from(user)),
+        None => Err("no such user".as_bytes().to_vec())
     }
 }
 
-/// Produce a property list consisting of the details of the given user.
+/// Produce a map consisting of the details of the given user.
 /// Keys include pw_uid, pw_gid, pw_name, pw_dir, and pw_shell.
-fn make_user_proplist(env: *mut ErlNifEnv, user: users::User) -> ERL_NIF_TERM {
-    let uid = unsafe { enif_make_uint(env, user.uid()) };
-    let uid_tuple = make_tuple(env, "pw_uid", &uid);
-    let gid = unsafe { enif_make_uint(env, user.primary_group_id()) };
-    let gid_tuple = make_tuple(env, "pw_gid", &gid);
-    let user_name = user.name();
-    let name_str = unsafe { enif_make_string_len(env, user_name.as_ptr(), user_name.len(),
-        ErlNifCharEncoding::ERL_NIF_LATIN1) };
-    let name_tuple = make_tuple(env, "pw_name", &name_str);
-    let home_dir = user.home_dir().to_str().unwrap();
-    let home_str = unsafe { enif_make_string_len(env, home_dir.as_ptr(), home_dir.len(),
-        ErlNifCharEncoding::ERL_NIF_LATIN1) };
-    let home_tuple = make_tuple(env, "pw_dir", &home_str);
-    let shell = user.shell().to_str().unwrap();
-    let shell_str = unsafe { enif_make_string_len(env, shell.as_ptr(), shell.len(),
-        ErlNifCharEncoding::ERL_NIF_LATIN1) };
-    let shell_tuple = make_tuple(env, "pw_shell", &shell_str);
-    let list_elems = [uid_tuple, gid_tuple, name_tuple, home_tuple, shell_tuple];
-    unsafe { enif_make_list_from_array(env, list_elems.as_ptr(), 5) }
+#[derive(NifMap)]
+struct User {
+    pub pw_uid: uid_t,
+    pub pw_gid: gid_t,
+    pub pw_name: Vec<u8>,
+    pub pw_dir: Vec<u8>,
+    pub pw_shell: Vec<u8>,
 }
 
-/// Produce a 2-tuple consisting of 'ok' and the given result.
-fn make_ok_result(env: *mut ErlNifEnv, result: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
-    make_tuple(env, "ok", result)
-}
-
-/// Produce a 2-tuple consisting of 'error' and the given reason.
-fn make_err_result(env: *mut ErlNifEnv, reason: &str) -> ERL_NIF_TERM {
-    let reason_str = unsafe { enif_make_string_len(env, reason.as_ptr(), reason.len(),
-        ErlNifCharEncoding::ERL_NIF_LATIN1) };
-    make_tuple(env, "error", &reason_str)
-}
-
-/// Produce a 2-tuple consisting of the label and the term.
-/// The label is converted to an atom.
-fn make_tuple(env: *mut ErlNifEnv, label: &str, result: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
-    let mut label_atom:ERL_NIF_TERM = unsafe { uninitialized() };
-    let c_label_str = CString::new(label).unwrap();
-    let c_label_nul = c_label_str.as_bytes_with_nul().as_ptr();
-    // Try using an existing atom, but if that fails, create a new one.
-    let atom_exists = unsafe { enif_make_existing_atom(
-        env, c_label_nul, &mut label_atom, ErlNifCharEncoding::ERL_NIF_LATIN1) };
-    if atom_exists == 0 {
-        label_atom = unsafe { enif_make_atom(env, c_label_nul) };
+impl From<users::User> for User {
+    fn from(user: users::User) -> User {
+        User{
+            pw_uid: user.uid(),
+            pw_gid: user.primary_group_id(),
+            pw_name: user.name().to_str().unwrap().as_bytes().to_vec(),
+            pw_dir: user.home_dir().to_str().unwrap().as_bytes().to_vec(),
+            pw_shell: user.shell().to_str().unwrap().as_bytes().to_vec(),
+        }
     }
-    let tuple_args = unsafe { [label_atom, *result] };
-    unsafe { enif_make_tuple_from_array(env, tuple_args.as_ptr(), 2) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,23 +27,18 @@ rustler::init!("epwd_rs", [getpwnam, getpwuid]);
 
 /// Retrieve the details for the named user as a property list.
 #[rustler::nif]
-fn getpwnam(name: Vec<u8>) -> Result<User, Vec<u8>> {
-   let rname = std::str::from_utf8(&name);
-   if rname.is_err() {
-       return Err("invalid name".as_bytes().to_vec());
-   }
-
-    match users::get_user_by_name(&rname.unwrap()) {
+fn getpwnam(name: String) -> Result<User, String> {
+    match users::get_user_by_name(&name) {
         Some(user) => Ok(User::from(user)),
-        None => Err("no such user".as_bytes().to_vec())
+        None => Err(String::from("no such user"))
     }
 }
 
 #[rustler::nif]
-fn getpwuid(uid: u32) -> Result<User, Vec<u8>> {
+fn getpwuid(uid: u32) -> Result<User, String> {
     match users::get_user_by_uid(uid as libc::uid_t) {
         Some(user) => Ok(User::from(user)),
-        None => Err("no such user".as_bytes().to_vec())
+        None => Err(String::from("no such user"))
     }
 }
 
@@ -53,9 +48,9 @@ fn getpwuid(uid: u32) -> Result<User, Vec<u8>> {
 struct User {
     pub pw_uid: uid_t,
     pub pw_gid: gid_t,
-    pub pw_name: Vec<u8>,
-    pub pw_dir: Vec<u8>,
-    pub pw_shell: Vec<u8>,
+    pub pw_name: String,
+    pub pw_dir: String,
+    pub pw_shell: String,
 }
 
 impl From<users::User> for User {
@@ -63,9 +58,9 @@ impl From<users::User> for User {
         User{
             pw_uid: user.uid(),
             pw_gid: user.primary_group_id(),
-            pw_name: user.name().to_str().unwrap().as_bytes().to_vec(),
-            pw_dir: user.home_dir().to_str().unwrap().as_bytes().to_vec(),
-            pw_shell: user.shell().to_str().unwrap().as_bytes().to_vec(),
+            pw_name: user.name().to_str().unwrap().to_string(),
+            pw_dir: user.home_dir().to_str().unwrap().to_string(),
+            pw_shell: user.shell().to_str().unwrap().to_string(),
         }
     }
 }

--- a/test/epwd_rs_SUITE.erl
+++ b/test/epwd_rs_SUITE.erl
@@ -45,20 +45,20 @@ test_getpwnam(_Config) ->
     % that the returned structure appears to be correct. Most values cannot be
     % asserted as they are system dependent.
     %
-    Username = os:getenv("USER", "root"),
+    Username = list_to_binary(os:getenv("USER", "root")),
     {ok, Results} = epwd_rs:getpwnam(Username),
     ?assert(is_map(Results)),
     ?assertEqual(5, maps:size(Results)),
     ?assert(is_integer(maps:get(pw_uid, Results))),
     ?assert(is_integer(maps:get(pw_gid, Results))),
     ?assertEqual(Username, maps:get(pw_name, Results)),
-    ?assert(is_list(maps:get(pw_dir, Results))),
-    ?assert(is_list(maps:get(pw_shell, Results))),
+    ?assert(is_binary(maps:get(pw_dir, Results))),
+    ?assert(is_binary(maps:get(pw_shell, Results))),
     %
     % Negative case, no such user
     %
-    {error, Reason} = epwd_rs:getpwnam("bozo"),
-    ?assertEqual("no such user", Reason),
+    {error, Reason} = epwd_rs:getpwnam(<<"bozo">>),
+    ?assertEqual(<<"no such user">>, Reason),
     ok.
 
 test_getpwuid(_Config) ->
@@ -71,7 +71,7 @@ test_getpwuid(_Config) ->
     ?assertEqual(5, maps:size(Results)),
     ?assertEqual(0, maps:get(pw_uid, Results)),
     ?assert(is_integer(maps:get(pw_gid, Results))),
-    ?assertEqual("root", maps:get(pw_name, Results)),
-    ?assert(is_list(maps:get(pw_dir, Results))),
-    ?assert(is_list(maps:get(pw_shell, Results))),
+    ?assertEqual(<<"root">>, maps:get(pw_name, Results)),
+    ?assert(is_binary(maps:get(pw_dir, Results))),
+    ?assert(is_binary(maps:get(pw_shell, Results))),
     ok.

--- a/test/epwd_rs_SUITE.erl
+++ b/test/epwd_rs_SUITE.erl
@@ -47,13 +47,13 @@ test_getpwnam(_Config) ->
     %
     Username = os:getenv("USER", "root"),
     {ok, Results} = epwd_rs:getpwnam(Username),
-    ?assert(is_list(Results)),
-    ?assertEqual(5, length(Results)),
-    ?assert(is_tuple(proplists:lookup(pw_uid, Results))),
-    ?assert(is_tuple(proplists:lookup(pw_gid, Results))),
-    ?assertEqual(Username, proplists:get_value(pw_name, Results)),
-    ?assert(is_tuple(proplists:lookup(pw_dir, Results))),
-    ?assert(is_tuple(proplists:lookup(pw_shell, Results))),
+    ?assert(is_map(Results)),
+    ?assertEqual(5, maps:size(Results)),
+    ?assert(is_integer(maps:get(pw_uid, Results))),
+    ?assert(is_integer(maps:get(pw_gid, Results))),
+    ?assertEqual(Username, maps:get(pw_name, Results)),
+    ?assert(is_list(maps:get(pw_dir, Results))),
+    ?assert(is_list(maps:get(pw_shell, Results))),
     %
     % Negative case, no such user
     %
@@ -67,11 +67,11 @@ test_getpwuid(_Config) ->
     % systems, and very likely has the name "root".
     %
     {ok, Results} = epwd_rs:getpwuid(0),
-    ?assert(is_list(Results)),
-    ?assertEqual(5, length(Results)),
-    ?assertEqual(0, proplists:get_value(pw_uid, Results)),
-    ?assert(is_tuple(proplists:lookup(pw_gid, Results))),
-    ?assertEqual("root", proplists:get_value(pw_name, Results)),
-    ?assert(is_tuple(proplists:lookup(pw_dir, Results))),
-    ?assert(is_tuple(proplists:lookup(pw_shell, Results))),
+    ?assert(is_map(Results)),
+    ?assertEqual(5, maps:size(Results)),
+    ?assertEqual(0, maps:get(pw_uid, Results)),
+    ?assert(is_integer(maps:get(pw_gid, Results))),
+    ?assertEqual("root", maps:get(pw_name, Results)),
+    ?assert(is_list(maps:get(pw_dir, Results))),
+    ?assert(is_list(maps:get(pw_shell, Results))),
     ok.


### PR DESCRIPTION
This Fixes #2 

Rustler tries to expose an idiomatic way to do things, so this PR introduces a bunch of backwards incompatible changes. Let me know what is unacceptable and I can work around it! The commits are split out pretty well.

- Return `map` objects instead of property lists. Rustler natively supports a `NifMap` struct derivation. I tried my hand at adding a `NifPropList` [here](https://github.com/mjsir911/rustler/commit/d8fca72158d9df891b6716d309b0820404db94ab), but didn't get very far.
- Accept & return `String` types instead of `Vec<u8>`. We're normalizing to `String` types anyways within rust, things are slightly more simple without the round trip back and forth.